### PR TITLE
Fix typo in Cassette module comment

### DIFF
--- a/src/Text/Cassette.hs
+++ b/src/Text/Cassette.hs
@@ -1,6 +1,6 @@
 -- | The combinators of this library are all pairs of functions going in
 -- opposite directions. These pairs are called /cassettes/, sporting two tracks
--- (the two functions), one of which is read is one direction, the other of
+-- (the two functions), one of which is read in one direction, the other of
 -- which (accessed by flipping the cassette) is read in the opposite direction.
 --
 -- = __Example__


### PR DESCRIPTION
## Summary
- fix a minor typo in `src/Text/Cassette.hs`

## Testing
- `treefmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404082135883239f92f81717c7a107