### PR TITLE
Fix doc comment syntax

### DIFF
--- a/src/Text/Cassette/Internal/Tr.hs
+++ b/src/Text/Cassette/Internal/Tr.hs
@@ -5,8 +5,8 @@ module Text.Cassette.Internal.Tr where
 import Control.Category (Category(..))
 import Prelude hiding (flip, id, (.))
 
---- | The type of string transformers in CPS, /i.e./ functions from strings to
---- strings.
+-- | The type of string transformers in CPS, /i.e./ functions from strings to
+-- strings.
 type C r = (String -> r) -> String -> r
 
 -- | @'Tr' r r'@ is the type of string transformers with answer type


### PR DESCRIPTION
## Summary
- correct doc comment prefix for type `C`

## Testing
- `cabal build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404079c4cc832398cdefd2d228c1f2